### PR TITLE
Fix historizing events with specified SourceNode

### DIFF
--- a/opcua/common/events.py
+++ b/opcua/common/events.py
@@ -24,7 +24,10 @@ class Event(object):
         self.select_clauses = None
         self.event_fields = None
         self.data_types = {}
-        self.emitting_node = emitting_node
+        if isinstance(emitting_node, ua.NodeId):
+            self.emitting_node = emitting_node
+        else:
+            self.emitting_node = ua.NodeId(emitting_node)
         # save current attributes
         self.internal_properties = list(self.__dict__.keys())[:] + ["internal_properties"]
 

--- a/opcua/server/history.py
+++ b/opcua/server/history.py
@@ -134,9 +134,9 @@ class HistoryDict(HistoryStorageInterface):
         self._events_periods[source_id] = period, count
 
     def save_event(self, event):
-        evts = self._events[event.SourceNode]
+        evts = self._events[event.emitting_node]
         evts.append(event)
-        period, count = self._events_periods[event.SourceNode]
+        period, count = self._events_periods[event.emitting_node]
         now = datetime.utcnow()
         if period:
             while len(evts) and now - evts[0].SourceTimestamp > period:

--- a/opcua/server/history_sql.py
+++ b/opcua/server/history_sql.py
@@ -163,7 +163,7 @@ class HistorySQLite(HistoryStorageInterface):
         with self._lock:
             _c_sub = self._conn.cursor()
 
-            table = self._get_table_name(event.SourceNode)
+            table = self._get_table_name(event.emitting_node)
             columns, placeholders, evtup = self._format_event(event)
             event_type = event.EventType  # useful for troubleshooting database
 
@@ -174,12 +174,12 @@ class HistorySQLite(HistoryStorageInterface):
                     .format(tn=table, co=columns, ts=event.Time, et=event_type, pl=placeholders), evtup)
 
             except sqlite3.Error as e:
-                self.logger.error('Historizing SQL Insert Error for events from %s: %s', event.SourceNode, e)
+                self.logger.error('Historizing SQL Insert Error for events from %s: %s', event.emitting_node, e)
 
             self._conn.commit()
 
             # get this node's period from the period dict and calculate the limit
-            period = self._datachanges_period[event.SourceNode]
+            period = self._datachanges_period[event.emitting_node]
 
             if period:
                 # after the insert, if a period was specified delete all records older than period
@@ -190,7 +190,7 @@ class HistorySQLite(HistoryStorageInterface):
                                    (date_limit.isoformat(' '),))
                 except sqlite3.Error as e:
                     self.logger.error('Historizing SQL Delete Old Data Error for events from %s: %s',
-                                      event.SourceNode, e)
+                                      event.emitting_node, e)
 
                 self._conn.commit()
 


### PR DESCRIPTION
History uses the emitting node to group events, but both implementations incorrectly
used event.SourceNode to sort events. This changes that, and also makes it so that the
emitting_node on events always is a NodeId, which was sometimes not the case before.